### PR TITLE
Fix spotify authorization for song playback

### DIFF
--- a/toplistadiscopolo/src/main/java/com/grandline/toplistadiscopolo/SpotifyService.java
+++ b/toplistadiscopolo/src/main/java/com/grandline/toplistadiscopolo/SpotifyService.java
@@ -522,6 +522,12 @@ public class SpotifyService {
         isConnecting = false;
         connectionRetryCount = 0;
         
+        // Cancel any pending timeout callbacks
+        if (connectionTimeoutRunnable != null) {
+            retryHandler.removeCallbacks(connectionTimeoutRunnable);
+            connectionTimeoutRunnable = null;
+        }
+        
         // Clear any existing connection
         if (mSpotifyAppRemote != null) {
             try {
@@ -532,7 +538,10 @@ public class SpotifyService {
             mSpotifyAppRemote = null;
         }
         
-        // Attempt new connection
-        connect();
+        // Small delay to ensure cleanup is complete before reconnecting
+        retryHandler.postDelayed(() -> {
+            Log.d(TAG, "Starting fresh connection attempt after cleanup");
+            connect();
+        }, 500);
     }
 }


### PR DESCRIPTION
Implement robust Spotify authorization callback handling and automatic track retry to resolve playback issues after re-authorization.

Previously, after a user re-authorized Spotify, the app failed to properly process the authorization callback, leading to a `UserNotAuthorizedException` and the inability to play the selected track. This PR ensures the app correctly handles the callback, reconnects to Spotify, and automatically resumes the track, providing a seamless user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-498b5264-81ef-4057-b9ad-21af34bcc497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-498b5264-81ef-4057-b9ad-21af34bcc497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

