### PR TITLE
Fix manifest placeholder errors

### DIFF
--- a/toplistadiscopolo/build.gradle
+++ b/toplistadiscopolo/build.gradle
@@ -12,6 +12,12 @@ android {
             useLibrary 'org.apache.http.legacy'
         }
         multiDexEnabled true
+        
+        // Manifest placeholders for redirect URI
+        manifestPlaceholders = [
+            redirectSchemeName: "com.grandline.toplistadiscopolo",
+            redirectHostName: "callback"
+        ]
     }
     buildTypes {
         release {

--- a/toplistadiscopolo/src/main/AndroidManifest.xml
+++ b/toplistadiscopolo/src/main/AndroidManifest.xml
@@ -68,8 +68,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 
                 <data 
-                    android:scheme="com.grandline.toplistadiscopolo"
-                    android:host="callback" />
+                    android:scheme="${redirectSchemeName}"
+                    android:host="${redirectHostName}" />
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
Resolve Android build errors by adding manifest placeholders for the Spotify redirect URI and updating AndroidManifest.xml to use them.

---
<a href="https://cursor.com/background-agent?bcId=bc-f23beb03-e3dc-460e-8fd9-90aa7f942788">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f23beb03-e3dc-460e-8fd9-90aa7f942788">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

