### PR TITLE
Fix spotify authorization invalid client secret

### DIFF
--- a/toplistadiscopolo/src/main/java/com/grandline/toplistadiscopolo/Constants.java
+++ b/toplistadiscopolo/src/main/java/com/grandline/toplistadiscopolo/Constants.java
@@ -22,6 +22,7 @@ public interface Constants {
 	String VALUE_START_NOTOWANIE_ID = "START_NOTOWANIE_ID";
 
 	String SPOTIFY_CLIENT_ID = "1ef55d5630814a3dafc946ef58e266b5";
+	String SPOTIFY_CLIENT_SECRET = "YOUR_CLIENT_SECRET_HERE"; // TODO: Replace with actual client secret from Spotify Dashboard
 	String SPOTIFY_REDIRECT_URI = "com.grandline.toplistadiscopolo://callback";
 	// XML node keys
 	String KEY_INFO = "info";


### PR DESCRIPTION
Add conditional client secret support for Spotify OAuth to resolve "Invalid client secret" errors with "Web App" configurations.

The previous implementation correctly used PKCE without a client secret, which is standard for mobile apps. However, if the Spotify app in the developer dashboard is configured as a "Web App", Spotify expects a client secret even with PKCE. This PR modifies the token exchange and refresh logic to conditionally include the client secret if it's provided in `Constants.java`, making the app compatible with both "Mobile App" and "Web App" Spotify dashboard configurations.

---
<a href="https://cursor.com/background-agent?bcId=bc-0340b3ac-1cc8-47b2-920b-4d2ead5287db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0340b3ac-1cc8-47b2-920b-4d2ead5287db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

