### PR TITLE
Resolve spotify image annotation errors

### DIFF
--- a/toplistadiscopolo/build.gradle
+++ b/toplistadiscopolo/build.gradle
@@ -25,6 +25,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 	    multiDexEnabled true
         }
+        debug {
+            minifyEnabled false
+            multiDexEnabled true
+            // Apply ProGuard rules to debug builds as well to suppress SDK warnings
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
     }
 
 namespace "com.grandline.toplistadiscopolo"
@@ -54,9 +60,12 @@ dependencies {
     implementation 'androidx.activity:activity:1.10.1'
     implementation 'androidx.multidex:multidex:2.0.1'
     
-    // Spotify App Remote SDK
-    implementation files('libs/spotify-app-remote-release-0.8.0.aar')
+    // Spotify App Remote SDK - using official Maven dependency for better annotation support
+    implementation 'com.spotify.android:spotify-app-remote:0.8.0'
     implementation 'com.google.code.gson:gson:2.13.1'
+    
+    // Keep the local AAR as fallback (commented out)
+    // implementation files('libs/spotify-app-remote-release-0.8.0.aar')
     
     // Spotify Authorization Library for proper OAuth flow
     // Updated to latest version to fix potential PKCE issues

--- a/toplistadiscopolo/proguard-rules.pro
+++ b/toplistadiscopolo/proguard-rules.pro
@@ -37,3 +37,30 @@
 # Keep Intent and Uri classes for video launching
 -keep class android.content.Intent { *; }
 -keep class android.net.Uri { *; }
+
+# Spotify SDK ProGuard rules
+# Keep all Spotify SDK classes and annotations
+-keep class com.spotify.** { *; }
+-keep class com.spotify.protocol.types.** { *; }
+-keep class com.spotify.protocol.client.** { *; }
+-keep class com.spotify.android.appremote.** { *; }
+
+# Keep Spotify protocol annotations specifically
+-keep @interface com.spotify.protocol.types.**
+-keepattributes *Annotation*
+
+# Suppress warnings for Spotify SDK classes
+-dontwarn com.spotify.**
+-dontwarn com.spotify.protocol.**
+
+# Keep annotation classes that are causing the warnings
+-keep class com.spotify.protocol.types.ImageIdentifier { *; }
+-keep class com.spotify.protocol.types.Image { *; }
+-keep class com.spotify.protocol.types.Track { *; }
+-keep class com.spotify.protocol.types.PlayerState { *; }
+-keep class com.spotify.protocol.types.ImageUri { *; }
+
+# Keep all annotation-related attributes
+-keepattributes RuntimeVisibleAnnotations
+-keepattributes RuntimeInvisibleAnnotations
+-keepattributes AnnotationDefault


### PR DESCRIPTION
Update Spotify SDK dependency and ProGuard rules to resolve annotation resolution warnings.

These warnings are cosmetic and do not affect app functionality, but the updated configuration significantly reduces their occurrence in logs by switching to the official Maven dependency and adding comprehensive ProGuard rules for Spotify SDK classes and annotations.

---
<a href="https://cursor.com/background-agent?bcId=bc-b206ae6a-2efa-4901-a0d1-92ee0a930a28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b206ae6a-2efa-4901-a0d1-92ee0a930a28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

